### PR TITLE
Fixed Drink URL

### DIFF
--- a/rooms.xml
+++ b/rooms.xml
@@ -46,9 +46,9 @@
 		<room name="Random Pillar in the L" 	rgb="116"></room>
 	</other>
 	<projects>
-		<room name="Big Drink" 		project_link="https://profiles.csh.rit.edu/user/drink"	info_link="https://wiki.csh.rit.edu/wiki/Big_Drink" 	link_title="Big Drink on the Wiki" rgb="244"></room>
-		<room name="Little Drink" 	project_link="https://profiles.csh.rit.edu/user/drink"	info_link="https://wiki.csh.rit.edu/wiki/Little_Drink" 	link_title="Little Drink on the Wiki" rgb="236"></room>
-		<room name="Snack" 			project_link="https://profiles.csh.rit.edu/user/drink"	info_link="https://wiki.csh.rit.edu/wiki/Snack" 		link_title="Snack on the Wiki" rgb="240"></room>
+		<room name="Big Drink" 		project_link="https://webdrink.csh.rit.edu"	info_link="https://wiki.csh.rit.edu/wiki/Big_Drink" 	link_title="Big Drink on the Wiki" rgb="244"></room>
+		<room name="Little Drink" 	project_link="https://webdrink.csh.rit.edu"	info_link="https://wiki.csh.rit.edu/wiki/Little_Drink" 	link_title="Little Drink on the Wiki" rgb="236"></room>
+		<room name="Snack" 			project_link="https://webdrink.csh.rit.edu"	info_link="https://wiki.csh.rit.edu/wiki/Snack" 		link_title="Snack on the Wiki" rgb="240"></room>
 	</projects>
 	<residentials>
 		<room name="Room 3009" resA="Unknown resident A" resA_year="unknown" resA_qualifications="" 	resA_link="" resA_link_title="future link for resident A" resB="None" resB_year="unknown" resB_qualifications="" resB_link="" resB_link_title="future link for resident B" rgb="120"></room>


### PR DESCRIPTION
Drink has changed. It's an endless stream of socialist soda drank by freshmen and visitors. Drink--and its consumption of debit--has become a well oiled machine. Drink has changed. RFID tagged CSHers carry RFID tagged lanyards, use RFID tagged projects. Caffeine inside their bodies enhances and regulates their abilities. Brand control. Energy control. Thirst control. Floor control. Everything is monitored and kept under control. Drink has changed.

Or not, I don't know. All I know is that the change to webdrink.csh has been finalized and I need to reflect such changes here.